### PR TITLE
Update postinstall script to reflect organization name change and latest version

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -27,8 +27,8 @@ const ext = platform === 'linux' ? 'tar.gz' : 'zip'
 
 const run = async () => {
   console.log('Downloading & extracting compiled sqldef binaries.')
-  const dataM = await rp({ url: `https://github.com/k0kubun/sqldef/releases/download/v0.5.7/mysqldef_${platform}_${arch}.${ext}`, method: 'GET', encoding: null })
-  const dataP = await rp({ url: `https://github.com/k0kubun/sqldef/releases/download/v0.5.7/psqldef_${platform}_${arch}.${ext}`, method: 'GET', encoding: null })
+  const dataM = await rp({ url: `https://github.com/sqldef/sqldef/releases/latest/download/mysqldef_${platform}_${arch}.${ext}`, method: 'GET', encoding: null })
+  const dataP = await rp({ url: `https://github.com/sqldef/sqldef/releases/latest/download/psqldef_${platform}_${arch}.${ext}`, method: 'GET', encoding: null })
   const getFile = ext === 'zip' ? unZipFile : unTarballFile
   await getFile(dataM, 'mysqldef', `${__dirname}/mysqldef`)
   await chmod(`${__dirname}/mysqldef`, '755')


### PR DESCRIPTION
Hello, @k0kubun 

I tried to use this script and installed it, but the download link in the `postinstall` script was outdated and no longer available. 

Therefore, I made the following changes:

- Updated the script to reflect the organization name change.
- Modified the script to download the latest version.

I hope these changes will be beneficial to the project. I would appreciate it if you could review and merge my changes.
Thank you!